### PR TITLE
Updated Login, Register ButtonBlocConsumer widgets

### DIFF
--- a/lib/src/features/login/presentation/widgets/login_button_bloc_consumer.dart
+++ b/lib/src/features/login/presentation/widgets/login_button_bloc_consumer.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:internship_ai_weather_app/src/core/helpers/extensions.dart';
 import 'package:internship_ai_weather_app/src/core/router/routes.dart';
 import 'package:internship_ai_weather_app/src/core/utils/functions/cache_user.dart';
+import 'package:internship_ai_weather_app/src/core/utils/functions/check_if_user_is_logged_in.dart';
 import 'package:internship_ai_weather_app/src/core/utils/functions/circular_indicator_or_text_widget.dart';
 import 'package:internship_ai_weather_app/src/core/widgets/custom_toast.dart';
 import 'package:internship_ai_weather_app/src/core/widgets/main_button.dart';
@@ -26,6 +27,7 @@ class LoginButtonBlocConsumer extends StatelessWidget {
             state: CustomToastState.error,
           ),
           loginSuccess: (appUser) async {
+            currentUser = appUser;
             await cacheUserAndHisId(appUser);
             context.pushReplacementNamed(Routes.homeRoute);
           },

--- a/lib/src/features/register/presentation/widgets/register_button_bloc_consumer.dart
+++ b/lib/src/features/register/presentation/widgets/register_button_bloc_consumer.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:internship_ai_weather_app/src/core/helpers/extensions.dart';
-import 'package:internship_ai_weather_app/src/core/router/routes.dart';
 import 'package:internship_ai_weather_app/src/core/utils/functions/circular_indicator_or_text_widget.dart';
 import 'package:internship_ai_weather_app/src/core/widgets/custom_toast.dart';
 import 'package:internship_ai_weather_app/src/core/widgets/main_button.dart';
@@ -24,8 +22,11 @@ class RegisterButtonBlocConsumer extends StatelessWidget {
             message: error,
             state: CustomToastState.error,
           ),
-          registerSuccess: (_) =>
-              context.pushReplacementNamed(Routes.homeRoute),
+          registerSuccess: (_) => CustomToast.showToast(
+            context: context,
+            message: "Account created successfully. Please login",
+            state: CustomToastState.success,
+          ),
         );
       },
       buildWhen: (_, current) =>


### PR DESCRIPTION
 - Assign the user's data to currentUser
 - Show a toast when register success instead of navigating to home route